### PR TITLE
チャット機能の不具合修正

### DIFF
--- a/app/assets/stylesheets/articles/articles.css
+++ b/app/assets/stylesheets/articles/articles.css
@@ -30,7 +30,7 @@
 }
 
 .side-bar{
-  width: 20vw;
+  min-width: 20vw;
   height: 100%;
   padding: 20px;
   border: 1px solid #d0bfc7;

--- a/app/assets/stylesheets/rooms/show.css
+++ b/app/assets/stylesheets/rooms/show.css
@@ -77,6 +77,7 @@
   background: #44281e;
   border: none;
   color: #fff !important;
+  font-weight: bold;
   cursor: pointer;
   border-radius: 3px;
   margin: 0 auto;

--- a/app/controllers/rooms_controller.rb
+++ b/app/controllers/rooms_controller.rb
@@ -31,6 +31,6 @@ class RoomsController < ApplicationController
   end
 
   def set_rooms
-    @rooms = current_user.rooms.joins(:messages).includes(:messages).order("messages.created_at DESC")
+    @rooms = current_user.rooms.joins(:entries).includes(:messages).order("messages.created_at DESC")
   end
 end

--- a/app/views/rooms/_rooms.html.erb
+++ b/app/views/rooms/_rooms.html.erb
@@ -32,14 +32,22 @@
           <div class="partner-name">
             <%= user.nickname %>
           </div>
-          <div class="partner-details">
-            <div class="latest-message">
-              <%= most_new_message_preview(room) %>
-            </div>
-            <div class="created-time">
-              <%= message_time(room) + '前'%>
-            </div>
-          </div> 
+          <% if room.messages.present? %>
+            <div class="partner-details">
+              <div class="latest-message">
+                <%= most_new_message_preview(room) %>
+              </div>
+              <div class="created-time">
+                <%= message_time(room) + '前'%>
+              </div>
+            </div> 
+          <% else %>
+            <div class="partner-details">
+              <div class="latest-message">
+                <p><%= "トークがありません" %></p>
+              </div>
+            </div> 
+          <% end %>
         </div>
       <% end %>
     </div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -13,7 +13,7 @@
     </ul>
     <ul class='lists-right'>
       <% if user_signed_in? %>
-        <li class="header-icons"><%= link_to rooms_path do %>
+        <li class="header-icons message-icon"><%= link_to rooms_path do %>
           <i class="fas fa-envelope fa-2x" style="color: #44281e"></i> <%#= メッセージ機能へのリンク %>
           <% end %></li>
         <li class="header-icons notification-icon"><%= link_to notifications_path do %> <%#= 通知機能へのリンク %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -55,12 +55,12 @@
                   <%= link_to 'チャットへ', room_path(@roomId), class:"mini-send-btn" %>
                   </div>
                 <% else %>
-                  <%= form_with model: @room do |f| %>
-                    <%= fields_for @entry do |e| %>
-                      <%= e.hidden_field :user_id, value: @user.id %>
+                    <%= form_with model: @room, local: true do |f| %>
+                      <%= fields_for @entry do |e| %>
+                        <%= e.hidden_field :user_id, value: @user.id %>
+                      <% end %>
+                      <%= f.submit "チャットを始める", class:"mini-send-btn user-show-chat" %>
                     <% end %>
-                    <%= button_tag type: 'submit', class:"btn btn-primary btn-lg user-show-chat" %>
-                  <% end %>
                 <% end %>
               <% end %>
             <% end %>

--- a/spec/system/messages_spec.rb
+++ b/spec/system/messages_spec.rb
@@ -7,43 +7,176 @@ def basic_pass(path)
 end
 
 def sign_in(user)
-  basic_pass root_path
-  visit root_path
   visit new_user_session_path
   fill_in 'email', with: user.email
   fill_in 'password', with: user.password
   find('input[name="commit"]').click
+  expect(current_path).to eq root_path
+  expect(page).to have_no_content('ログイン')
+end
+
+def sign_out
+  # ページヘッダーからマイページへのリンクを特定する
+  expect(page).to have_selector(".user-nickname")
+  find('.user-nickname').click
+  # サインアウトする
+  expect(page).to have_selector(".sign-out")
+  find('.sign-out').click
+  expect(current_path).to eq root_path
 end
 
 RSpec.describe "Messages", type: :system do
   before do
     @user = FactoryBot.create(:user)
     @another_user = FactoryBot.create(:user)
-    # 相手からのフォローを構築
-    @relationship2 = Relationship.new(user_id: @another_user.id, follow_id: @user.id)
+    @message = FactoryBot.build(:message)
     sleep(0.1)
   end
 
   context 'メッセージができるとき' do
     it '相互フォロー同士でroomを生成し、メッセージのやりとりができる' do
-      # ログインし、root_pathにいることを確認する
+      # @another_userでログインする
+      basic_pass root_path
+      visit root_path
+      sign_in(@another_user)
+      # @userの詳細ページへ遷移する
+      visit user_path(@user)
+      # @userをフォローするボタンがあることを確認する
+      expect(page).to have_selector(".follow-btn")
+      # @userをフォロー、Relationshipカウントが1上がることを確認する
+      expect{find('.follow-btn').click}.to change { Relationship.count }.by(1)
+      # @another_userはマイページに戻り、ログアウトする
+      sign_out
+      # @userでログインする
       sign_in(@user)
+      # @another_userからフォローされていることを確認する
+      expect(page).to have_selector('.notification-icon')
+      find('.notification-icon').click
+      expect(current_path).to eq notifications_path
+      expect(page).to have_content("#{@another_user.nickname} さんが あなたをフォローしました")
       # @another_userのページに遷移する
       visit user_path(@another_user)
       expect(current_path).to eq user_path(@another_user)
-      # 「チャットへ」のボタンがあることを確認する
+      # 「フォローする」のボタンがあることを確認する
       expect(page).to have_selector(".follow-btn")
-      find(".follow-btn").click
+      # @another_userをフォローする ページは遷移していないことを確認する
+      expect{find('.follow-btn').click}.to change { Relationship.count }.by(1)
       expect(current_path).to eq user_path(@another_user)
-      # 「チャットへ」のボタンがあることを確認する
+      # ページに「チャットを始める」のボタンが出現していることを確認する
       expect(page).to have_selector('.user-show-chat')
+      # 「チャットを始める」をクリックし、room#indexに遷移していることを確認する
       find('.user-show-chat').click
-      binding.pry
-      # リロードする
+      expect(page).to have_content('メッセージはありません')
+      # メッセージの入力フォームを特定する
+      expect(page).to have_selector('.form-text-field')
+      # メッセージフォームに入力し、送信する。Messageカウントが1上がることを確認する
+      fill_in 'メッセージを入力して下さい', with: @message.message
+      expect{find('.posts').find('button[name="button"]').click}.to change { Message.count }.by(1)
+      # このページに@message.messageが存在していることを確認
+      expect(page).to have_content(@message.message)
+      # サインアウトする（@another_userでメッセージの存在を確認していく）
+      sign_out
+      # 再び@another_userでサインインする
+      sign_in(@another_user)
+      # 画面ヘッダーにあるレターアイコンから、メッセージ機能のページへ遷移していく
+      expect(page).to have_selector('.message-icon')
+      find('.message-icon').click
+      expect(current_path).to eq rooms_path
+      # @userとのメッセージルームへ遷移していく
+      expect(page).to have_link(@user.nickname)
+      find('.room').click
+      # ページに先ほどの@message.messageが存在するか確認する
+      expect(page).to have_content(@message.message)
+    end
+  end
+  context 'メッセージができないとき' do
+    it '@userが@another_userをフォローしていないとroomに入ってもメッセージができない' do
+      # @another_userでログインする
+      basic_pass root_path
+      visit root_path
+      sign_in(@another_user)
+      # @userの詳細ページへ遷移する
+      visit user_path(@user)
+      # @userをフォローするボタンがあることを確認する
+      expect(page).to have_selector(".follow-btn")
+      # @userをフォロー、Relationshipカウントが1上がることを確認する
+      expect{find('.follow-btn').click}.to change { Relationship.count }.by(1)
+      # @another_userはマイページに戻り、ログアウトする
+      sign_out
+      # @userでログインする
+      sign_in(@user)
+      # @another_userからフォローされていることを確認する
+      expect(page).to have_selector('.notification-icon')
+      find('.notification-icon').click
+      expect(current_path).to eq notifications_path
+      expect(page).to have_content("#{@another_user.nickname} さんが あなたをフォローしました")
+      # トップページに戻り、メッセージルームのページに遷移する
+      visit root_path
+      expect(page).to have_selector('.message-icon')
+      find('.message-icon').click
+      expect(current_path).to eq rooms_path
+      # このページに@another_userとのルームが存在しないことを確認する
+      expect(page).to have_no_link(@user.nickname)
+    end
+    it 'ログインしていないユーザーがトップページから強制的にrooms_pathに遷移してもできない' do
+      basic_pass root_path
+      visit root_path
+      visit rooms_path
+      expect(current_path).to eq new_user_session_path
+    end
+    it '空欄のメッセージは送信できない' do
+      # @another_userでログインする
+      basic_pass root_path
+      visit root_path
+      sign_in(@another_user)
+      # @userの詳細ページへ遷移する
+      visit user_path(@user)
+      # @userをフォローするボタンがあることを確認する
+      expect(page).to have_selector(".follow-btn")
+      # @userをフォロー、Relationshipカウントが1上がることを確認する
+      expect{find('.follow-btn').click}.to change { Relationship.count }.by(1)
+      # @another_userはマイページに戻り、ログアウトする
+      sign_out
+      # @userでログインする
+      sign_in(@user)
+      # @another_userからフォローされていることを確認する
+      expect(page).to have_selector('.notification-icon')
+      find('.notification-icon').click
+      expect(current_path).to eq notifications_path
+      expect(page).to have_content("#{@another_user.nickname} さんが あなたをフォローしました")
+      # @another_userのページに遷移する
+      visit user_path(@another_user)
       expect(current_path).to eq user_path(@another_user)
-      visit current_path
-      # 「チャットへ」のボタンがあることを確認する
-      expect(page).to have_link('チャットへ')
+      # 「フォローする」のボタンがあることを確認する
+      expect(page).to have_selector(".follow-btn")
+      # @another_userをフォローする ページは遷移していないことを確認する
+      expect{find('.follow-btn').click}.to change { Relationship.count }.by(1)
+      expect(current_path).to eq user_path(@another_user)
+      # ページに「チャットを始める」のボタンが出現していることを確認する
+      expect(page).to have_selector('.user-show-chat')
+      # 「チャットを始める」をクリックし、room#indexに遷移していることを確認する
+      find('.user-show-chat').click
+      expect(page).to have_content('メッセージはありません')
+      # メッセージの入力フォームを特定する
+      expect(page).to have_selector('.form-text-field')
+      # メッセージフォームに''を入力し、送信する。Messageカウントは上がらないことを確認する
+      fill_in 'メッセージを入力して下さい', with: ''
+      expect{find('.posts').find('button[name="button"]').click}.to change { Message.count }.by(0)
+      # このページに@message.messageが存在していることを確認
+      expect(page).to have_no_content(@message.message)
+      # サインアウトする（@another_userでメッセージの存在を確認していく）
+      sign_out
+      # 再び@another_userでサインインする
+      sign_in(@another_user)
+      # 画面ヘッダーにあるレターアイコンから、メッセージ機能のページへ遷移していく
+      expect(page).to have_selector('.message-icon')
+      find('.message-icon').click
+      expect(current_path).to eq rooms_path
+      # @userとのメッセージルームへ遷移していく
+      expect(page).to have_link(@user.nickname)
+      find('.room').click
+      # ページに@messageも存在しないことを確認する
+      expect(page).to have_no_content(@message.message)
     end
   end
 end


### PR DESCRIPTION
# WHAT
チャット機能（メッセージ機能）の不具合を修正

①メッセージルーム一覧に、相互フォローのユーザーが一覧で表示されていなかった
　旧）メッセージ履歴のあるルームのみ表示されていた
　変）メッセージの有無に関係なく、メッセージのできるユーザーの一覧を表示

②メッセージルームの生成ボタンの不具合を修正
　旧）一度生成のボタンをクリックして、リロードしてからメッセージルームへ遷移する必要があった
　変）生成ボタンをクリックすると自動でメッセージルームへ遷移するようにした

上記修正を踏まえ、最後にはMessage関連の結合テストを実行