### PR TITLE
投稿ボタンの変更

### DIFF
--- a/app/assets/stylesheets/articles/articles.css
+++ b/app/assets/stylesheets/articles/articles.css
@@ -143,6 +143,34 @@
 .tags{
   height: 3vh;
 }
+
+.click-post{
+  background-color:#44281e;
+  position: fixed;
+  bottom: 5vh;
+  right: 3vw;
+  width: 80px;
+  height: 80px;
+  border-radius: 50%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.click-post:hover{
+  opacity: 0.8;
+  text-decoration: none;
+}
+
+
+.post-icon{
+  color: #ffffff;
+}
+
+.sp-btn{
+  display: none;
+}
+
 /* //ログイン後の表示 */
 
 @media screen and (max-width:767px) {
@@ -231,5 +259,22 @@
     width: 50px;
     height: 50px;
   }
+
+
+  .click-post{
+    bottom: 3vh;
+    right: 3vw;
+    width: 60px;
+    height: 60px;
+  }
+
+  .sp-btn{
+    display: flex;
+  }
+
+  .pc-btn{
+    display: none;
+  }
+
 
 }

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -3,7 +3,6 @@
     <%= render "shared/logout_index" %>
   <% else %>
     <%= render "shared/header" %>
-    <%= render "shared/post-bar" %>
     <div class="flash-notifications">
       <% flash.each do |key, value| %>
         <%= content_tag(:div, value, class: key) %>
@@ -16,6 +15,12 @@
           <%= render partial:"article", collection: @search_articles_result, locals: {article: @article} %>
         <% else %>
           <%= render partial:"article", collection: @articles, locals: {article: @article} %>
+        <% end %>
+        <%= link_to new_article_path, class: "click-post drop-shadow pc-btn" do%>
+          <i class="fas fa-pencil-alt fa-3x post-icon"></i>
+        <% end %>
+        <%= link_to new_article_path, class: "click-post drop-shadow sp-btn" do%>
+          <i class="fas fa-pencil-alt fa-2x post-icon"></i>
         <% end %>
       </div>
     </div>

--- a/app/views/ko/articles/_index.html.erb
+++ b/app/views/ko/articles/_index.html.erb
@@ -2,7 +2,6 @@
   <%= render "ko/shared/logout_index" %>
 <% else %>
   <%= render "ko/shared/header" %>
-  <%= render "ko/shared/post-bar" %>
   <div class="flash-notifications">
     <% flash.each do |key, value| %>
       <%= content_tag(:div, value, class: key) %>
@@ -15,6 +14,12 @@
         <%= render partial:"ko/articles/article", collection: @search_articles_result, locals: {article: @article} %>
       <% else %>
         <%= render partial:"ko/articles/article", collection: @articles, locals: {article: @article} %>
+      <% end %>
+      <%= link_to new_article_path, class: "click-post drop-shadow pc-btn" do%>
+        <i class="fas fa-pencil-alt fa-3x post-icon"></i>
+      <% end %>
+      <%= link_to new_article_path, class: "click-post drop-shadow sp-btn" do%>
+        <i class="fas fa-pencil-alt fa-2x post-icon"></i>
       <% end %>
     </div>
   </div>

--- a/app/views/ko/notifications/_index.html.erb
+++ b/app/views/ko/notifications/_index.html.erb
@@ -16,4 +16,10 @@
       <% end %>
       </div>
   </div>
+  <%= link_to new_article_path, class: "click-post drop-shadow pc-btn" do%>
+    <i class="fas fa-pencil-alt fa-3x post-icon"></i>
+  <% end %>
+  <%= link_to new_article_path, class: "click-post drop-shadow sp-btn" do%>
+    <i class="fas fa-pencil-alt fa-2x post-icon"></i>
+  <% end %>
 </div>

--- a/app/views/ko/rooms/_index.html.erb
+++ b/app/views/ko/rooms/_index.html.erb
@@ -1,7 +1,4 @@
 <%= render "ko/shared/header" %>
-<div class="pc-size">
-  <%= render "ko/shared/post-bar" %>
-</div>
 <div class='main'>
   <div class="room-main">
     <%= render "ko/rooms/rooms" %>

--- a/app/views/ko/rooms/_show.html.erb
+++ b/app/views/ko/rooms/_show.html.erb
@@ -1,7 +1,4 @@
 <%= render "ko/shared/header" %>
-<div class="pc-size">
-  <%= render "ko/shared/post-bar" %>
-</div>
 <div class="flash-notifications">
   <% flash.each do |key, value| %>
     <%= content_tag(:div, value, class: key) %>

--- a/app/views/ko/users/_show.html.erb
+++ b/app/views/ko/users/_show.html.erb
@@ -1,10 +1,5 @@
 <%= render "ko/shared/header" %>
 <div class="post-bar">
-  <div class="post-btn">
-    <%= link_to  new_article_path, class: "post-btn" do%>
-      올리다 <i class="fas fa-pencil-alt"></i>
-    <% end %>
-  </div>
   <% if @user == current_user %>
     <div class="post-btn">
       <%= link_to  destroy_user_session_path, method: :delete, class: "post-btn sign-out" do %>
@@ -132,4 +127,10 @@
       </div>
     </div>
   </div>
+  <%= link_to new_article_path, class: "click-post drop-shadow pc-btn" do%>
+    <i class="fas fa-pencil-alt fa-3x post-icon"></i>
+  <% end %>
+  <%= link_to new_article_path, class: "click-post drop-shadow sp-btn" do%>
+    <i class="fas fa-pencil-alt fa-2x post-icon"></i>
+  <% end %>
 </div>

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -1,8 +1,5 @@
 <% if I18n.locale.to_s == "ja"%>
   <%= render "shared/header" %>
-  <div class="pc-size">
-    <%= render "shared/post-bar" %>
-  </div>
   <div class="main">
     <div class="pc-size">
       <%= render "shared/side-bar" %>
@@ -17,6 +14,12 @@
         <% end %>
         </div>
     </div>
+    <%= link_to new_article_path, class: "click-post drop-shadow pc-btn" do%>
+      <i class="fas fa-pencil-alt fa-3x post-icon"></i>
+    <% end %>
+    <%= link_to new_article_path, class: "click-post drop-shadow sp-btn" do%>
+      <i class="fas fa-pencil-alt fa-2x post-icon"></i>
+    <% end %>
   </div>
 <% else %>
   <%= render "ko/notifications/index" %>

--- a/app/views/rooms/index.html.erb
+++ b/app/views/rooms/index.html.erb
@@ -1,8 +1,5 @@
 <% if I18n.locale.to_s == "ja"%>
   <%= render "shared/header" %>
-  <div class="pc-size">
-    <%= render "shared/post-bar" %>
-  </div>
   <div class='main'>
     <div class="room-main">
       <%= render "rooms" %>

--- a/app/views/rooms/show.html.erb
+++ b/app/views/rooms/show.html.erb
@@ -1,8 +1,5 @@
 <% if I18n.locale.to_s == "ja"%>
   <%= render "shared/header" %>
-  <div class="pc-size">
-    <%= render "shared/post-bar" %>
-  </div>
   <div class="flash-notifications">
     <% flash.each do |key, value| %>
       <%= content_tag(:div, value, class: key) %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,11 +1,6 @@
 <% if I18n.locale.to_s == "ja"%>
   <%= render "shared/header" %>
   <div class="post-bar">
-    <div class="post-btn">
-      <%= link_to  new_article_path, class: "post-btn" do%>
-        投稿する <i class="fas fa-pencil-alt"></i>
-      <% end %>
-    </div>
     <% if @user == current_user %>
       <div class="post-btn">
         <%= link_to  destroy_user_session_path, method: :delete, class: "post-btn sign-out" do %>
@@ -134,6 +129,12 @@
         </div>
       </div>
     </div>
+    <%= link_to new_article_path, class: "click-post drop-shadow pc-btn" do%>
+      <i class="fas fa-pencil-alt fa-3x post-icon"></i>
+    <% end %>
+    <%= link_to new_article_path, class: "click-post drop-shadow sp-btn" do%>
+      <i class="fas fa-pencil-alt fa-2x post-icon"></i>
+    <% end %>
   </div>
 <% else %>
   <%= render "ko/users/show" %>


### PR DESCRIPTION
# WHAT
新規投稿ページへのリンクボタンを仕様変更

画面右下に鉛筆マークのアイコンを固定表示させる、このボタンをクリックすると新規投稿ページへ遷移できる
画面ヘッダー部に設置されていた「投稿する」というボタンは排除する